### PR TITLE
ITP Share problem with fire fox

### DIFF
--- a/Firefox
+++ b/Firefox
@@ -1,0 +1,1 @@
+ITP Share > Facebook Like and send button does'n works with Firefox (v.17.0.1)


### PR DESCRIPTION
ITP Share > Facebook Like and send button does'n works with Firefox (v.17.0.1).

This with the plugin for Joomla v. 2.5.7.

With Safari works!
